### PR TITLE
スケジュール管理からチームメンバー表示名変更機能の実装

### DIFF
--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -44,6 +44,8 @@ ja:
         contact_address: 連絡先
         comment: コメント
         image: LINEQRコード等
+      team_member:
+        display_name: 表示名
     models:
       user: ユーザー
   devise:

--- a/spec/models/team_member_spec.rb
+++ b/spec/models/team_member_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe TeamMember, type: :model do
       expect(team_member1).not_to be_valid
     end
 
+    it '表示名が長すぎる場合、無効である' do
+      team_member1.display_name = 'a' * 51
+      expect(team_member1).not_to be_valid
+    end
+
     it '1つのチームに同じユーザーが2回以上保存されないこと' do
       team_member = build(:team_member1, user: user, team: team)
       expect(team_member).not_to be_valid

--- a/spec/system/team/team_members_edit_spec.rb
+++ b/spec/system/team/team_members_edit_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe 'チームメンバーの表示名変更テスト', type: :system do
+  let!(:user) { FactoryBot.create(:user) }
+  let!(:team) { FactoryBot.create(:team) }
+  let!(:other_user) { FactoryBot.create(:other_user) }
+  let!(:team_member1) { FactoryBot.create(:team_member1, team: team, user: user) }
+  let!(:team_member2) { FactoryBot.create(:team_member2, team: team, user: other_user) }
+  let!(:event) { FactoryBot.create(:event) }
+
+  describe 'チームメンバーの表示名を変更する' do
+    it 'チーム管理者はスケジュール管理から全てのチームメンバーの表示名を変更できる' do
+      log_in_as(user)
+      click_on 'スケジュール管理'
+      expect(page).to have_current_path event_path(team.id), ignore_query: true
+      expect(page).to have_content('ジロー', count: 1)
+      expect(page).to have_content('じろー', count: 0)
+      click_on 'ジロー'
+      expect(page).to have_current_path edit_team_team_member_path(team_member2.id), ignore_query: true
+      fill_in 'team_member[display_name]', with: 'じろー'
+      click_on '更新する'
+      expect(page).to have_current_path event_path(team.id), ignore_query: true
+      expect(page).to have_selector('.alert-success', text: '表示名を更新しました')
+      expect(page).to have_content('ジロー', count: 0)
+      expect(page).to have_content('じろー', count: 1)
+    end
+  end
+end


### PR DESCRIPTION
スケジュール管理からのチームメンバー表示名変更機能の実装をしました。
レビューの程よろしくお願いいたします。